### PR TITLE
Add Canvas API integration commands to import roster and list classes

### DIFF
--- a/canvas.py
+++ b/canvas.py
@@ -1,0 +1,72 @@
+import http.client
+import json
+import logging
+import time
+
+__author__ = 'Islam Elnabarawy'
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+class CanvasAPI:
+    REQUEST_HEADER = {
+        "Authorization": "Bearer ",
+        "Content-Type": "application/json"
+    }
+    WEBSITE_ROOT = "https://mst.instructure.com"
+
+    def __init__(self, canvas_token):
+        self.REQUEST_HEADER['Authorization'] += canvas_token
+
+    def _request(self, method: str, url: str, params: dict = None, retries: int = 3) -> http.client.HTTPResponse:
+        tries = 0
+        while tries <= retries:
+            try:
+                connection = http.client.HTTPSConnection('mst.instructure.com', 443)
+                connection.connect()
+                header = self.REQUEST_HEADER
+                connection.request(method, url, (json.dumps(params) if params is not None else None), header)
+                return connection.getresponse()
+            except Exception as ex:
+                tries += 1
+                if tries > retries:
+                    raise ex
+                logging.warning("Caught exception in request after %d tries. Will retry %d more times.",
+                                tries, retries - tries, exc_info=True)
+                time.sleep(1)
+
+    @staticmethod
+    def _decode_links(link):
+        links = link.split(',')
+        result = {}
+        for l in links:
+            f, s = l.split(';')
+            result[s[6:-1]] = f[1:-2].replace(CanvasAPI.WEBSITE_ROOT, '')
+        return result
+
+    def _get_all_pages(self, url: str, params: dict = None) -> list:
+        response = self._request('GET', url, params)
+        result = json.loads(response.read().decode())
+        links = CanvasAPI._decode_links(response.getheader("Link"))
+        count = len(result)
+        page = 1
+        while 'next' in links:
+            logging.debug("Got links:\n" + json.dumps(links, sort_keys=True, indent=2))
+            page += 1
+            next_url = url.split('?')[0] + '?page=%s&per_page=%s' % (page, count)
+            logging.info("Getting next page for " + url + " via " + next_url)
+            response = self._request('GET', next_url, params)
+            result.extend(json.loads(response.read().decode()))
+            links = CanvasAPI._decode_links(response.getheader("Link"))
+
+        return result
+
+    def get_teacher_courses(self):
+        result = self._get_all_pages('/api/v1/courses',
+                                     {'enrollment_type': 'teacher', 'state': ['available']})
+        return result
+
+    def get_course_students(self, course_id):
+        result = self._get_all_pages('/api/v1/courses/%s/users?per_page=50' % course_id,
+                                     {'enrollment_type': ['student'], 'enrollment_state': ['active']})
+        return result

--- a/canvas.py
+++ b/canvas.py
@@ -5,8 +5,6 @@ import time
 
 __author__ = 'Islam Elnabarawy'
 
-logging.basicConfig(level=logging.DEBUG)
-
 
 class CanvasAPI:
     REQUEST_HEADER = {

--- a/config.py
+++ b/config.py
@@ -85,6 +85,11 @@ class Config(UserDict):
                     "additionalProperties": False,
                 },
             },
+
+            # Canvas API token
+            "canvas-token": {
+                "type": "string",
+            },
         },
         "required": ["gitlab-host", "namespace", "token", "semester"],
         "additionalProperties": False,


### PR DESCRIPTION
This pull request adds 1 new configuration key and 2 new commands:

The configuration key is **canvas-token**, which can be created by going to your profile settings page in Canvas and at the bottom clicking the button that says "New Access Token". This will allow you to use the Canvas API as yourself through assigner.

The new commands are:
* **list_courses**: shows a list of the courses where the current user is a teacher. You can use this command to find the course's ID. You can also find the course's ID by looking at the URL when you open the Canvas course in the browser, but this is slightly more convenient.
* **canvas_import**: imports the list of users from Canvas, given the course's Canvas ID.

I've tested it out on my own course and it works. I plan to add future commands to allow updating the roster in case someone was added or dropped, but for now this still has to be done manually.