### PR TITLE
Implement --student option for (un)lock, (un)archive, and get.

### DIFF
--- a/assigner.py
+++ b/assigner.py
@@ -513,6 +513,8 @@ def make_parser():
                                         "access to")
     subparser.add_argument("--section", nargs="?",
                            help="Section to grant access to")
+    subparser.add_argument("--student", metavar="id",
+                           help="ID of the student to assign to.")
     subparser.set_defaults(run=open_assignment)
 
     # "get" command

--- a/assigner.py
+++ b/assigner.py
@@ -60,15 +60,18 @@ def assign(conf, args):
     namespace = conf.namespace
     token = conf.token
     semester = conf.semester
-    if section:
+    if target:
+        roster = [s for s in conf.roster if s["username"] == target]
+    elif section:
         roster = [s for s in conf.roster if s["section"] == section]
     else:
         roster = conf.roster
+
+    if not roster:
+        raise ValueError("No matching students found in roster.")
+
     actual_count = 0  # Represents the number of repos actually pushed to
     student_count = len(roster)
-
-    if target:
-        raise NotImplementedError("'--student' is not implemented")
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         print("Assigning '{}' to {} student{} in {}.".format(
@@ -134,14 +137,20 @@ def open_assignment(conf, args):
     """
     hw_name = args.name
     section = args.section
+    target = args.student  # used if assigning to a single student
     host = conf.gitlab_host
     namespace = conf.namespace
     token = conf.token
     semester = conf.semester
-    if section:
+    if target:
+        roster = [s for s in conf.roster if s["username"] == target]
+    elif section:
         roster = [s for s in conf.roster if s["section"] == section]
     else:
         roster = conf.roster
+
+    if not roster:
+        raise ValueError("No matching students found in roster.")
 
     count = 0
     for student in roster:
@@ -174,16 +183,21 @@ def get(conf, args):
     hw_path = args.path
     section = args.section
     target = args.student  # used if assigning to a single student
-    if target:
-        raise NotImplementedError("'--student' is not implemented")
     host = conf.gitlab_host
     namespace = conf.namespace
     token = conf.token
     semester = conf.semester
-    if section:
+
+    if target:
+        roster = [s for s in conf.roster if s["username"] == target]
+    elif section:
         roster = [s for s in conf.roster if s["section"] == section]
     else:
         roster = conf.roster
+
+    if not roster:
+        raise ValueError("No matching students found in roster.")
+
     path = os.path.join(hw_path, hw_name)
     os.makedirs(path, mode=0o700, exist_ok=True)
 
@@ -246,17 +260,20 @@ def manage_users(conf, args, level):
 
     if dry_run:
         raise NotImplementedError("'--dry-run' is not implemented")
-    if target:
-        raise NotImplementedError("'--student' is not implemented")
 
     host = conf.gitlab_host
     namespace = conf.namespace
     token = conf.token
     semester = conf.semester
-    if section:
+    if target:
+        roster = [s for s in conf.roster if s["username"] == target]
+    elif section:
         roster = [s for s in conf.roster if s["section"] == section]
     else:
         roster = conf.roster
+
+    if not roster:
+        raise ValueError("No matching students found in roster.")
 
     count = 0
     for student in roster:
@@ -399,8 +416,6 @@ def manage_repos(conf, args, action):
 
     if dry_run:
         raise NotImplementedError("'--dry-run' is not implemented")
-    if target:
-        raise NotImplementedError("'--student' is not implemented")
     if action not in ['archive', 'unarchive']:
         raise ValueError("Unexpected action '{}', accepted actions are 'archive' and 'unarchive'.".format(action))
 
@@ -408,10 +423,16 @@ def manage_repos(conf, args, action):
     namespace = conf.namespace
     token = conf.token
     semester = conf.semester
-    if section:
+
+    if target:
+        roster = [s for s in conf.roster if s["username"] == target]
+    elif section:
         roster = [s for s in conf.roster if s["section"] == section]
     else:
         roster = conf.roster
+
+    if not roster:
+        raise ValueError("No matching students found in roster.")
 
     count = 0
     for student in roster:

--- a/assigner.py
+++ b/assigner.py
@@ -59,7 +59,7 @@ def assign(conf, args):
     token = conf.token
     semester = conf.semester
 
-    roster = get_selected_roster(args)
+    roster = get_filtered_roster(conf.roster, args.section, args.student)
 
     actual_count = 0  # Represents the number of repos actually pushed to
     student_count = len(roster)
@@ -132,7 +132,7 @@ def open_assignment(conf, args):
     token = conf.token
     semester = conf.semester
 
-    roster = get_selected_roster(args)
+    roster = get_filtered_roster(conf.roster, args.section, args.student)
 
     count = 0
     for student in roster:
@@ -168,7 +168,7 @@ def get(conf, args):
     token = conf.token
     semester = conf.semester
 
-    roster = get_selected_roster(args)
+    roster = get_filtered_roster(conf.roster, args.section, args.student)
 
     path = os.path.join(hw_path, hw_name)
     os.makedirs(path, mode=0o700, exist_ok=True)
@@ -236,7 +236,7 @@ def manage_users(conf, args, level):
     token = conf.token
     semester = conf.semester
 
-    roster = get_selected_roster(args)
+    roster = get_filtered_roster(conf.roster, args.section, args.student)
 
     count = 0
     for student in roster:
@@ -385,7 +385,7 @@ def manage_repos(conf, args, action):
     token = conf.token
     semester = conf.semester
 
-    roster = get_selected_roster(args)
+    roster = get_filtered_roster(conf.roster, args.section, args.student)
 
     count = 0
     for student in roster:
@@ -412,16 +412,11 @@ def manage_repos(conf, args, action):
     print("Changed {} repositories.".format(count))
 
 
-@config_context
-def get_selected_roster(conf, args):
-    section = args.section
-    target = args.student  # used if assigning to a single student
+def get_filtered_roster(roster, section, target):
     if target:
-        roster = [s for s in conf.roster if s["username"] == target]
+        roster = [s for s in roster if s["username"] == target]
     elif section:
-        roster = [s for s in conf.roster if s["section"] == section]
-    else:
-        roster = conf.roster
+        roster = [s for s in roster if s["section"] == section]
     if not roster:
         raise ValueError("No matching students found in roster.")
     return roster


### PR DESCRIPTION
The --student option supersedes the --section option, and an error message is displayed if the matching list of students is empty.

Makes progress towards issue #7.