### PR TITLE
Fix an error that was causing new repo creation to fail

### DIFF
--- a/baserepo.py
+++ b/baserepo.py
@@ -304,7 +304,7 @@ class BaseRepo(Repo):
             "builds_enabled": False,
             "wiki_enabled": False,
             "snippets_enabled": True,  # Why not?
-            "visibility_level": Visibility.private,
+            "visibility_level": Visibility.private.value,
         }
 
         result = cls._cls_gl_post(url_base, "/projects", token, payload)
@@ -332,7 +332,7 @@ class StudentRepo(Repo):
             "builds_enabled": False,
             "wiki_enabled": False,
             "snippets_enabled": True,  # Why not?
-            "visibility_level": Visibility.private,
+            "visibility_level": Visibility.private.value,
         }
 
         result = cls._cls_gl_post(base_repo.url_base, "/projects",


### PR DESCRIPTION
The value for the visibility_level parameter was incorrect, and GitLab
was returning an HTTP 400 error whenever the new command was used.