### PR TITLE
Workaround for BSD readlink

### DIFF
--- a/assigner
+++ b/assigner
@@ -1,5 +1,13 @@
 #! /bin/sh
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+
+# Check for -f (BSD coreutils doesn't have it)
+readlink -f "$0" &> /dev/null
+
+if [ "$?" != "0" ]; then
+  SCRIPT_DIR=$(cd "$(dirname "$0")" ; pwd -P)
+else
+  SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+fi
 VENV_DIR="$SCRIPT_DIR/.assigner-virtualenv"
 
 if [ ! -d "$VENV_DIR" ]; then

--- a/update-requirements
+++ b/update-requirements
@@ -1,5 +1,12 @@
 #! /bin/sh
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+# Check for -f (BSD coreutils doesn't have it)
+readlink -f "$0" &> /dev/null
+
+if [ "$?" != "0" ]; then
+  SCRIPT_DIR=$(cd "$(dirname "$0")" ; pwd -P)
+else
+  SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+fi
 VENV_DIR="$SCRIPT_DIR/.assigner-virtualenv"
 
 if [ ! -d "$VENV_DIR" ]; then


### PR DESCRIPTION
OS X has BSD's readlink... which means that -f doesn't work properly. This is now detected so OS X clients can run assigner.