### PR TITLE
Add ability to protect/unprotect branches

### DIFF
--- a/assigner.py
+++ b/assigner.py
@@ -32,12 +32,13 @@ subcommands = OrderedDict([
     ("unlock", "commands.unlock"),
     ("archive", "commands.archive"),
     ("unarchive", "commands.unarchive"),
+    ("protect", "commands.protect"),
+    ("unprotect", "commands.unprotect"),
     ("status", "commands.status"),
     ("import", "commands.import"),
     ("canvas", "commands.canvas"),
     ("set", "commands.set"),
 ])
-
 
 @config_context
 def manage_users(conf, args, level):
@@ -81,15 +82,10 @@ def manage_users(conf, args, level):
 
 @config_context
 def manage_repos(conf, args, action):
-    """Performs an action (archive|unarchive) on all student repos
+    """Performs an action (lambda) on all student repos
     """
     hw_name = args.name
     dry_run = args.dry_run
-
-    if dry_run:
-        raise NotImplementedError("'--dry-run' is not implemented")
-    if action not in ['archive', 'unarchive']:
-        raise ValueError("Unexpected action '{}', accepted actions are 'archive' and 'unarchive'.".format(action))
 
     host = conf.gitlab_host
     namespace = conf.namespace
@@ -112,10 +108,8 @@ def manage_repos(conf, args, action):
 
         try:
             repo = StudentRepo(host, namespace, full_name, token)
-            if action == 'archive':
-                repo.archive()
-            else:
-                repo.unarchive()
+            if not dry_run:
+                action(repo)
             count += 1
         except HTTPError:
             raise

--- a/baserepo.py
+++ b/baserepo.py
@@ -261,6 +261,12 @@ class Repo(object):
     def unarchive(self):
         return self._gl_post("/projects/{}/unarchive".format(self.id))
 
+    def protect(self, branch="master"):
+        return self._gl_put("/projects/{}/repository/branches/{}/protect".format(self.id, branch))
+
+    def unprotect(self, branch="master"):
+        return self._gl_put("/projects/{}/repository/branches/{}/unprotect".format(self.id, branch))
+
     def _gl_get(self, path, params={}):
         return self.__class__._cls_gl_get(
             self.url_base, path, self.token, params

--- a/commands/archive.py
+++ b/commands/archive.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def archive(args):
     """Archive each student repository so it won't show up in the project list.
     """
-    return manage_repos(args, 'archive')
+    return manage_repos(args, lambda repo: repo.archive())
 
 
 def setup_parser(parser):

--- a/commands/assign.py
+++ b/commands/assign.py
@@ -57,6 +57,7 @@ def assign(conf, args):
                     repo = StudentRepo.new(base, semester, student_section,
                                            username, token)
                     repo.push(base, branch)
+                    repo.unprotect(branch)
                 actual_count += 1
                 logging.debug("Assigned.")
             elif force:
@@ -70,12 +71,15 @@ def assign(conf, args):
                     repo = StudentRepo.new(base, semester, student_section,
                                            username, token)
                     repo.push(base, branch)
+                    repo.unprotect(branch)
                 actual_count += 1
                 logging.debug("Assigned.")
             elif args.branch:
                 logging.info("{}: Already exists.".format(full_name))
                 # If we have an explicit branch, push anyways
-                repo.push(base, branch) if not dry_run else None
+                if not dry_run:
+                    repo.push(base, branch)
+                    repo.unprotect(branch)
                 actual_count += 1
                 logging.debug("Assigned.")
             else:

--- a/commands/protect.py
+++ b/commands/protect.py
@@ -1,0 +1,26 @@
+import logging
+
+from assigner import manage_repos
+
+help="Protect a repo branch"
+
+logger = logging.getLogger(__name__)
+
+
+def protect(args):
+    """Protect a branch in each student's repository so they cannot force push to it."""
+    branch = args.branch if args.branch else "master"
+    return manage_repos(args, lambda repo: repo.protect(branch))
+
+def setup_parser(parser):
+    parser.add_argument("name",
+                           help="Name of the assignment to protect.")
+    parser.add_argument("--branch",
+                           help="Branch to protect (default: master).")
+    parser.add_argument("--section", nargs="?",
+                           help="Section to protect")
+    parser.add_argument("--student", metavar="id",
+                           help="ID of student whose assignment to protect.")
+    parser.add_argument("--dry-run", action="store_true",
+                           help="Don't actually do it.")
+    parser.set_defaults(run=protect)

--- a/commands/unarchive.py
+++ b/commands/unarchive.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def unarchive(args):
     """Unarchive each student repository so it will show back up in the project list.
     """
-    return manage_repos(args, 'unarchive')
+    return manage_repos(args, lambda repo: repo.archive())
 
 
 def setup_parser(parser):

--- a/commands/unprotect.py
+++ b/commands/unprotect.py
@@ -1,0 +1,26 @@
+import logging
+
+from assigner import manage_repos
+
+help="Unprotect a repo branch"
+
+logger = logging.getLogger(__name__)
+
+def unprotect(args):
+    """Unprotect a branch in each student's repository so they can force push to it."""
+    branch = args.branch if args.branch else "master"
+    return manage_repos(args, lambda repo: repo.unprotect(branch))
+
+def setup_parser(parser):
+    parser.add_argument("name",
+                           help="Name of the assignment to unprotect.")
+    parser.add_argument("--branch",
+                           help="Branch to unprotect (default: master).")
+    parser.add_argument("--section", nargs="?",
+                           help="Section to unprotect")
+    parser.add_argument("--student", metavar="id",
+                           help="ID of student whose assignment to unprotect.")
+    parser.add_argument("--dry-run", action="store_true",
+                           help="Don't actually do it.")
+    parser.set_defaults(run=unprotect)
+


### PR DESCRIPTION
At least one of my students has been confused by gitlab protecting master by default. This PR unprotects branches by default and allows you to protect/unprotect them as desired.

I also made some changes to how `manage_repo` works so that it's more generally useful. *sips functional kool-aid*

Also, this completes the `--dry-run` feature for everything using `manage_repo`, so it closes #7!