### PR TITLE
Throw exception if we attempt to access repo attributes that are not set

### DIFF
--- a/baserepo.py
+++ b/baserepo.py
@@ -124,10 +124,16 @@ class Repo(object):
 
     @property
     def namespace_id(self):
+        if not self.already_exists():
+            raise RepoError("Repo {} does not exist on Gitlab".format(self.name))
+
         return self.info["namespace"]["id"]
 
     @property
     def id(self):
+        if not self.already_exists():
+            raise RepoError("Repo {} does not exist on Gitlab".format(self.name))
+
         return self.info["id"]
 
     @property
@@ -153,6 +159,9 @@ class Repo(object):
 
     @property
     def ssh_url(self):
+        if not self.already_exists():
+            raise RepoError("Repo {} does not exist on Gitlab".format(self.name))
+
         return self.info["ssh_url_to_repo"]
 
     def already_exists(self):
@@ -161,9 +170,6 @@ class Repo(object):
         return False
 
     def clone_to(self, dir_name, branch=None):
-        if not self.already_exists():
-            raise RepoError("Repo {} does not exist on Gitlab".format(self.name))
-
         if branch:
             self._repo = git.Repo.clone_from(self.ssh_url, dir_name,
                                              branch=branch)


### PR DESCRIPTION
In the case that a repo does not exist on gitlab, accessing its id, etc.
currently results in

```
TypeError: 'NoneType' object is not subscriptable
```

which is less than ideal. This fixes that problem by throwing a more reasonable
exception; this also makes for better error messages elsewhere.

Closes #37