### PR TITLE
Sort canvas courses by descending ID

### DIFF
--- a/commands/canvas.py
+++ b/commands/canvas.py
@@ -75,7 +75,7 @@ def print_canvas_courses(conf, args):
     output = PrettyTable(["#", "ID", "Name"])
     output.align["Name"] = "l"
 
-    for ix, c in enumerate(courses):
+    for ix, c in enumerate(sorted(courses, key=lambda c: c['id'], reverse=True)):
         output.add_row((ix+1, c['id'], c['name']))
 
     print(output)


### PR DESCRIPTION
It appears that Canvas course IDs are ordered by time. Displaying them from largest to smallest thus makes it likely that the newest courses will appear first in the list, where people are likely to look first when trying to use the canvas command. 