### PR TITLE
Return [] if roster is missing from config

### DIFF
--- a/config.py
+++ b/config.py
@@ -132,7 +132,7 @@ class Config(UserDict):
         try:
             return self.data[key]
         except KeyError as e:
-            if key == 'roster':
+            if key == "roster":
                 self.data[key] = []
                 return self.data[key]
             raise e

--- a/config.py
+++ b/config.py
@@ -128,4 +128,11 @@ class Config(UserDict):
             return attr
         # Keys contained dashes can be called using an underscore
         key = key.replace("_", "-")
-        return self.data[key]
+
+        try:
+            return self.data[key]
+        except KeyError as e:
+            if key == 'roster':
+                self.data[key] = []
+                return self.data[key]
+            raise e

--- a/roster_util.py
+++ b/roster_util.py
@@ -20,6 +20,8 @@ def add_to_roster(conf, roster, name, username, section, force=False):
         "section": section
     }
 
+    logger.debug("{}".format(roster))
+
     if not force and any([s['username'] == username for s in roster]):
       raise DuplicateUserError("Student already exists in roster!")
 


### PR DESCRIPTION
This fixes a situation where you run `assigner init` then `assigner roster add bob bob a` or something and assigner promptly barfs all over because there's no roster there.
Ideally we could set default values as part of the big json blob in `config.py` but I don't know if jsonschema is going to be happy with extra crap stuck in.

I don't particularly like this approach but I'm not sure what a better one would be.

Kinda fixes #58 a little.

@brhoades @michaelwisely opinions?