### PR TITLE
Display push time in status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Devel
 
 - Rename `token` to `gitlab-token` in the configuration file
+- Display push time, rather than commit time, in `status` output
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Rename `token` to `gitlab-token` in the configuration file
 - Display push time, rather than commit time, in `status` output
+- Show push time in human-readable format in the current locale's timezone
 
 ## 0.1.0
 

--- a/assigner/commands/status.py
+++ b/assigner/commands/status.py
@@ -35,7 +35,7 @@ def status(conf, args):
 
     output = PrettyTable([
         "#", "Sec", "SID", "Name", "Status", "Branches",
-        "HEAD", "Last Commit Author", "Last Commit Time"])
+        "HEAD", "Last Commit Author", "Last Push Time"])
     output.align["Name"] = "l"
     output.align["Last Commit Author"] = "l"
 
@@ -85,10 +85,9 @@ def status(conf, args):
             if branches:
                 row[5] = ", ".join([b["name"] for b in branches])
 
-            commits = repo.list_commits()
+            head = repo.get_last_HEAD_commit()
 
-            if commits:
-                head = commits[0]
+            if head:
                 row[6] = head["short_id"]
                 row[7] = head["author_name"]
                 created_at = head["created_at"]

--- a/assigner/commands/status.py
+++ b/assigner/commands/status.py
@@ -93,7 +93,9 @@ def status(conf, args):
                 created_at = head["created_at"]
                 # Fix UTC offset format in GitLab's datetime
                 created_at = created_at[:-6] + created_at[-6:].replace(':', '')
-                row[8] = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%S.%f%z")
+                row[8] = datetime.strptime(
+                    created_at, "%Y-%m-%dT%H:%M:%S.%f%z"
+                ).astimezone().strftime("%c")
 
             output.add_row(row)
 


### PR DESCRIPTION
Also display time in a more human-readable format.

Closes #69 in part; the remainder will be left for a future feature.