### PR TITLE
Catch HTTP 409 when adding students to repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Devel
 
+- Warn when an assignment is already open for a student when running `open`
+
 ## 1.0.0
 
 - Rename `token` to `gitlab-token` in the configuration file

--- a/assigner/commands/open.py
+++ b/assigner/commands/open.py
@@ -42,8 +42,11 @@ def open_assignment(conf, args):
             count += 1
         except RepoError:
             logging.warn("Could not add {} to {}.".format(username, full_name))
-        except HTTPError:
-            raise
+        except HTTPError as e:
+            if e.response.status_code == 409:
+                logging.warning("%s is already a member of %s.", username, full_name)
+            else:
+                raise
 
     progress.finish()
 


### PR DESCRIPTION
An HTTP 409 indicates that the student is already a member.