### PR TITLE
Add --open flag for assign & open error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## Devel
 
+- Warn when an assignment is already open for a student when running `open`
+- Calling `assign` with the `--open` flag assigns and opens an assignment in one step
 - Removed remaining lint as specified by pylint.
 - Removed old baserepo standalone code.
 - Added Travis CI config for pylint and pyflakes.
-- Warn when an assignment is already open for a student when running `open`
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Removed remaining lint as specified by pylint.
 - Removed old baserepo standalone code.
 - Added Travis CI config for pylint and pyflakes.
+- Warn when an assignment is already open for a student when running `open`
 
 ## 1.0.0
 

--- a/assigner/commands/assign.py
+++ b/assigner/commands/assign.py
@@ -4,6 +4,7 @@ import time
 
 from assigner.roster_util import get_filtered_roster
 from assigner.baserepo import BaseRepo, StudentRepo, RepoError
+from assigner.commands.open import open_assignment
 from assigner.config import config_context
 from assigner.progress import Progress
 
@@ -118,6 +119,9 @@ def assign(conf, args):
                 logging.info("%s: Already exists, skipping...", full_name)
             i += 1
 
+            if args.open:
+                open_assignment(repo, student)
+
     progress.finish()
 
     print("Assigned '{}' to {} student{}.".format(
@@ -145,4 +149,6 @@ def setup_parser(parser):
     parser.add_argument("-f", "--force", action="store_true", dest="force",
                         help="Delete and recreate already existing "
                         "student repos.")
+    parser.add_argument("-o", "--open", action="store_true", dest="open",
+                        help="Open assignment after assigning")
     parser.set_defaults(run=assign)

--- a/assigner/commands/open.py
+++ b/assigner/commands/open.py
@@ -11,9 +11,18 @@ help = "Grants students access to their repos"
 
 logger = logging.getLogger(__name__)
 
+def open_assignment(repo, student):
+    try:
+        logging.debug("Opening %s...", repo.name)
+        repo.add_member(student["id"], Access.developer)
+    except HTTPError as e:
+        if e.response.status_code == 409:
+            logging.warning("%s is already a member of %s.", student["username"], repo.name)
+        else:
+            raise
 
 @config_context
-def open_assignment(conf, args):
+def open_all_assignments(conf, args):
     """Adds each student in the roster to their respective homework
     repositories as Developers so they can pull/commit/push their work.
     """
@@ -38,15 +47,10 @@ def open_assignment(conf, args):
             if "id" not in student:
                 student["id"] = Repo.get_user_id(username, host, token)
 
-            repo.add_member(student["id"], Access.developer)
+            open_assignment(repo, student)
             count += 1
         except RepoError:
             logging.warning("Could not add %s to %s.", username, full_name)
-        except HTTPError as e:
-            if e.response.status_code == 409:
-                logging.warning("%s is already a member of %s.", username, full_name)
-            else:
-                raise
 
     progress.finish()
 
@@ -60,4 +64,4 @@ def setup_parser(parser):
                         help="Section to grant access to")
     parser.add_argument("--student", metavar="id",
                         help="ID of the student to assign to.")
-    parser.set_defaults(run=open_assignment)
+    parser.set_defaults(run=open_all_assignments)

--- a/assigner/commands/open.py
+++ b/assigner/commands/open.py
@@ -42,8 +42,11 @@ def open_assignment(conf, args):
             count += 1
         except RepoError:
             logging.warning("Could not add %s to %s.", username, full_name)
-        except HTTPError:
-            raise
+        except HTTPError as e:
+            if e.response.status_code == 409:
+                logging.warning("%s is already a member of %s.", username, full_name)
+            else:
+                raise
 
     progress.finish()
 


### PR DESCRIPTION
Lets you open and assign in one shot -- handy for adding students to your roster after you've already assigned and opened a homework.

Also, catch an HTTP 409 when adding a student to a repo. That indicates that the student is already a member.

Closes #60. Obsoletes #100.