### PR TITLE
BUG: git clone does not like being passed a list of branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Devel
 
+- Fixed `get` failing to clone new repos with error `Remote branch ['master'] not found in upstream origin`
+
 ## 1.1.0
 
 - Warn when an assignment is already open for a student when running `open`

--- a/assigner/baserepo.py
+++ b/assigner/baserepo.py
@@ -190,12 +190,11 @@ class Repo(object):
 
         self.repo.remote().pull(branch)
 
-    def clone_to(self, dir_name, branch=None):
+    def clone_to(self, dir_name, branch):
         logging.debug("Cloning %s...", self.ssh_url)
         try:
             if branch:
-                self._repo = git.Repo.clone_from(self.ssh_url, dir_name,
-                                                 branch=branch)
+                self._repo = git.Repo.clone_from(self.ssh_url, dir_name)
                 for b in branch:
                     self._repo.create_head(b, "origin/{}".format(b))
 

--- a/assigner/commands/get.py
+++ b/assigner/commands/get.py
@@ -100,15 +100,15 @@ def get(conf, args):
                                         username, b)
                         logging.warning("  (use --force to overwrite)")
 
-                # Check out first branch specified; this is probably what people expect
-                # If there's just one branch, it's already checked out by the loop above
-                if len(branch) > 1:
-                    repo.get_head(branch[0]).checkout()
-
             except NoSuchPathError:
                 logging.debug("Local repo does not exist; cloning...")
                 repo.clone_to(repo_dir, branch)
                 output.add_row([row, sec, sid, name, "Cloned a new copy"])
+
+            # Check out first branch specified; this is probably what people expect
+            # If there's just one branch, it's already checked out by the loop above
+            if len(branch) > 1:
+                repo.get_head(branch[0]).checkout()
 
         except RepoError as e:
             logging.warning(e)


### PR DESCRIPTION
This now causes `assigner get` to behave similarly when fetching and
cloning: first the repo is fetched/cloned, then the requested branches
are created or updated, then the first requested branch is checked out.