### PR TITLE
[WIP] Commit and Push commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Devel
 
+- Added 'push' command to push commits to student repos
 - Retry clones that fail with 'Connection reset by peer' using exponential backoff
 - Offer to create GitLab group in `assigner init`
 - Version configuration; automatically upgrade old configs to latest version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Devel
 
+- Added 'commit' command to commit changes to student repos
 - Added 'push' command to push commits to student repos
 - Retry clones that fail with 'Connection reset by peer' using exponential backoff
 - Offer to create GitLab group in `assigner init`

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -159,6 +159,41 @@ If you encounter 'Connection reset by peer' errors when cloning, run, say, `assi
 (Assigner doesn't have plans for any grading features;
 however, if you are interested in automated grading, check out its sister project, [grader](https://github.com/redkyn/grader).)
 
+### Committing and pushing changes to student repositories
+
+You can make and push commits to student repositories after they have been created with `assigner assign` by using `assigner commit` and `assigner push`.
+These commands should be used carefully!
+It is quite possible to give your students merge conflicts if they are still making commits to their repository while you are making changes.
+We recommend using this feature very carefully if students are intended to continue working in their repos after you push your commits.
+
+We recommend using the following workflow with `commit` and `push`:
+
+1. Lock student repositories with `assigner lock`.
+    This will prevent students from pushing to their repositories before you push your changes.
+2. Clone or pull local copies of their repositories using `assigner get`.
+3. Make the changes you require in each repository.
+4. Commit your changes.
+    `assigner commit assignment-name "my commit message"` behaves effectively like executing `git checkout master; git commit -am "my commit message` in each student repository.
+    Add new files by specifying their names after the `-a` flag; remove files by specifying their names after the `-r` flag.
+
+    To add all untracked files in each student's repository, run `assigner commit assignment-name "commit message" -a "*"`.
+
+    As a more extended example, the command 
+    ```
+    assigner commit assignment-name "my commit message" -a newfile.txt -r junk.dat -u --branch devel
+    ```
+    corresponds to executing the following commands in each repository:
+    ```
+    git checkout devel
+    git add newfile.txt
+    git rm junk.dat
+    git commit --all --message="my commit message"
+    ```
+5. Push your commits with `assigner push`.
+    If you did not lock the students' repositories, Assigner will print an error and exit.
+    We recommend locking their repositories, then updating your local copies with `assigner get` before pushing.
+    However, if you are absolutely sure of what you are doing, you can override this check with the `--push-unlocked` flag.
+
 ### Student repository management
 
 If you wish to prevent students from submitting after the deadline, you may lock their repositories by running `assigner lock hw1`.

--- a/assigner/__init__.py
+++ b/assigner/__init__.py
@@ -41,6 +41,7 @@ subcommands = [
     "assign",
     "open",
     "get",
+    "commit",
     "push",
     "lock",
     "unlock",

--- a/assigner/__init__.py
+++ b/assigner/__init__.py
@@ -17,6 +17,7 @@ import sys
 
 from colorlog import ColoredFormatter
 from git.cmd import GitCommandNotFound
+from requests.exceptions import HTTPError
 
 from assigner.backends.decorators import requires_config_and_backend
 from assigner.roster_util import get_filtered_roster
@@ -40,6 +41,7 @@ subcommands = [
     "assign",
     "open",
     "get",
+    "push",
     "lock",
     "unlock",
     "archive",
@@ -77,15 +79,20 @@ def manage_repos(conf, backend, args, action):
                 "Student %s does not have a gitlab account.", username
             )
             continue
+
         full_name = backend.student_repo.build_name(semester, student_section,
                                                     hw_name, username)
 
-        repo = backend.student_repo(backend_conf, namespace, full_name)
-        if not dry_run:
-            if action(repo, student):
+        try:
+            repo = backend.student_repo(backend_conf, namespace, full_name)
+            if not dry_run:
+                if action(repo, student):
+                    count += 1
+            else:
                 count += 1
-        else:
-            count += 1
+        except HTTPError:
+            logging.warning("Error processing %s", username)
+            raise
 
     print("Changed {} repositories.".format(count))
 

--- a/assigner/backends/gitlab.py
+++ b/assigner/backends/gitlab.py
@@ -344,6 +344,10 @@ class GitlabRepo(RepoBase):
             "/projects/{}/members/{}".format(self.id, user_id)
         )
 
+    def is_locked(self):
+        access = [Access(m["access_level"]) for m in self.list_members()]
+        return all([a in (Access.guest, Access.reporter) for a in access])
+
     def list_commits(self, ref_name="master"):
         params = {
             "id": self.id,

--- a/assigner/backends/gitlab.py
+++ b/assigner/backends/gitlab.py
@@ -194,6 +194,12 @@ class GitlabRepo(RepoBase):
             return True
         return False
 
+    def get_index(self):
+        if self.repo is None:
+            raise RepoError("No repo to get index from")
+
+        return self.repo.index
+
     def get_head(self, branch):
         if self.repo is None:
             raise RepoError("No repo to get head from")

--- a/assigner/commands/commit.py
+++ b/assigner/commands/commit.py
@@ -1,0 +1,120 @@
+import logging
+import os
+
+from requests.exceptions import HTTPError
+from git.exc import NoSuchPathError
+
+from assigner.roster_util import get_filtered_roster
+from assigner.backends import RepoError
+from assigner.backends.decorators import requires_config_and_backend
+from assigner import progress
+
+help = "Add and commit changes to student repos"
+
+logger = logging.getLogger(__name__)
+
+
+@requires_config_and_backend
+def push(conf, backend, args):
+    _push(conf, backend, args)
+
+def _push(conf, backend, args):
+    backend_conf = conf.backend
+    namespace = conf.namespace
+    semester = conf.semester
+
+    hw_name = args.name
+    hw_path = args.path
+    message = args.message
+    branch = args.branch
+    add = args.add
+    remove = args.remove
+    update = args.update
+    allow_empty = args.allow_empty
+
+    # Default behavior: commit changes to all tracked files
+    if (add == []) and (remove == []):
+        logging.debug("Nothing explicitly added or removed; defaulting to git add --update")
+        update = True
+
+    path = os.path.join(hw_path, hw_name)
+
+    roster = get_filtered_roster(conf.roster, args.section, args.student)
+
+    for student in progress.iterate(roster):
+        username = student["username"]
+        student_section = student["section"]
+        full_name = backend.student_repo.build_name(semester, student_section,
+                                                    hw_name, username)
+
+        has_changes = False
+
+        try:
+            repo = backend.student_repo(backend_conf, namespace, full_name)
+            repo_dir = os.path.join(path, username)
+            repo.add_local_copy(repo_dir)
+
+            logging.debug("%s: checking out branch %s", full_name, branch)
+            repo.get_head(branch).checkout()
+            index = repo.get_index()
+
+            if update:
+                # Stage modified and deleted files for commit
+                # This exactly mimics the behavior of git add --update
+                # (or the effect of doing git commit -a)
+                for change in index.diff(None):
+                    has_changes = True
+                    if change.deleted_file:
+                        logging.debug("%s: git rm %s", full_name, change.b_path)
+                        index.remove([change.b_path])
+                    else:
+                        logging.debug("%s: git add %s", full_name, change.b_path)
+                        index.add([change.b_path])
+
+            if add:
+                has_changes = True
+                logging.debug("%s: adding %s", full_name, add)
+                index.add(add)
+            if remove:
+                has_changes = True
+                logging.debug("%s: removing %s", full_name, remove)
+                index.remove(remove)
+
+            if has_changes or allow_empty:
+                logging.debug("%s: committing changes with message %s", full_name, message)
+                index.commit(message)
+            else:
+                logging.warning("%s: No changes in repo; skipping commit.", full_name)
+
+        except NoSuchPathError:
+            logging.warning("Local repo for %s does not exist; skipping...", username)
+        except RepoError as e:
+            logging.warning(e)
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                logging.warning("Repository %s does not exist.", full_name)
+            else:
+                raise
+
+def setup_parser(parser):
+    parser.add_argument("name",
+                        help="Name of the assignment to commit to.")
+    parser.add_argument("message",
+                        help="Commit message")
+    parser.add_argument("path", default=".", nargs="?",
+                        help="Path of student repositories to commit to")
+    parser.add_argument("--branch", nargs="?", default="master",
+                        help="Local branch to commit to")
+    parser.add_argument("-a", "--add", nargs="+", dest="add", default=[],
+                        help="Files to add before committing")
+    parser.add_argument("-r", "--remove", nargs="+", dest="remove", default=[],
+                        help="Files to remove before committing")
+    parser.add_argument("-u", "--update", action="store_true", dest="update",
+                        help="Include all changed files (i.e., git add -u or git commit -a)")
+    parser.add_argument("-e", "--allow-empty", action="store_true", dest="allow_empty",
+                        help="Commit even if there are no changes to commit")
+    parser.add_argument("--section", nargs="?",
+                        help="Section to commit to")
+    parser.add_argument("--student", metavar="id",
+                        help="ID of student whose assignment is to be committed to.")
+    parser.set_defaults(run=push)

--- a/assigner/commands/push.py
+++ b/assigner/commands/push.py
@@ -1,0 +1,81 @@
+import logging
+import os
+
+from requests.exceptions import HTTPError
+from git.exc import NoSuchPathError
+
+from assigner.roster_util import get_filtered_roster
+from assigner.backends import RepoError
+from assigner.backends.decorators import requires_config_and_backend
+from assigner import progress
+
+help = "Push changes to student repos"
+
+logger = logging.getLogger(__name__)
+
+
+@requires_config_and_backend
+def push(conf, backend, args):
+    _push(conf, backend, args)
+
+def _push(conf, backend, args):
+    hw_name = args.name
+    hw_path = args.path
+    namespace = conf.namespace
+    semester = conf.semester
+    backend_conf = conf.backend
+    branch = args.branch
+    force = args.force
+    push_unlocked = args.push_unlocked
+
+    path = os.path.join(hw_path, hw_name)
+
+    roster = get_filtered_roster(conf.roster, args.section, args.student)
+
+    for student in progress.iterate(roster):
+        username = student["username"]
+        student_section = student["section"]
+        full_name = backend.student_repo.build_name(semester, student_section,
+                                                    hw_name, username)
+
+        try:
+            repo = backend.student_repo(backend_conf, namespace, full_name)
+            repo_dir = os.path.join(path, username)
+            repo.add_local_copy(repo_dir)
+
+            if repo.is_locked() or push_unlocked:
+                info = repo.repo.remote().push(branch, force=force, set_upstream=True)
+                for line in info:
+                    logging.debug("%s: flags: %s, branch: %s, summary: %s", full_name, line.flags, line.local_ref, line.summary)
+                    if line.flags & line.ERROR:
+                        logging.warning("%s: push to %s failed: %s", full_name, line.local_ref, line.summary)
+            else:
+                logging.warning("%s: repo is not locked (run 'assigner lock %s' first)", full_name, hw_name)
+
+        except NoSuchPathError:
+            logging.warning("Local repo for %s does not exist; skipping...", username)
+        except RepoError as e:
+            logging.warning(e)
+        except HTTPError as e:
+            if e.response.status_code == 404:
+                logging.warning("Repository %s does not exist.", full_name)
+            else:
+                raise
+
+
+def setup_parser(parser):
+    parser.add_argument("name",
+                        help="Name of the assignment to push.")
+    parser.add_argument("path", default=".", nargs="?",
+                        help="Path to push student repositories from")
+    parser.add_argument("--branch", "--branches", nargs="+", default=["master"],
+                        help="Local branch or branches to push")
+    parser.add_argument("-f", "--force", action="store_true", dest="force",
+                        help="Force-push student repositories")
+    parser.add_argument("-u", "--push-unlocked", action="store_true", dest="push_unlocked",
+                        help="Push to student repos even if they are unlocked")
+    parser.add_argument("--section", nargs="?",
+                        help="Section to push")
+    parser.add_argument("--student", metavar="id",
+                        help="ID of student whose assignment needs pushing.")
+    parser.set_defaults(run=push)


### PR DESCRIPTION
This pair of commands will allow people to push local changes to students' repos. For example, autograder output can be added and pushed once grading is complete.

We have no plans to add a "copy this file to all local student repos" feature. If necessary, this can be done from a shell like so:

```bash
for dir in hw1/*; do [[ -d $dir ]] && cp updated-file $dir/original-file; done
```

The push command is written to, by default, require you to lock student repos before pushing to them. This will reduce the possibility of conflicts; however, it is impossible to avoid conflicts on the students' side if they have un-pushed commits before `assigner push` is run. We recommend using this feature very carefully if students are intended to continue working in their repos after the push occurs (i.e., if `assigner push` is used to update an assignment after it has been assigned and opened).

Closes #98, closes #138.

TODO:
- [x] Changelog
- [x] Tutorial docs
- [ ] Integration tests