### PR TITLE
Use a shared HTTPS session for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## Devel
 
 - Print informative message if `git` is not installed
+- Use a shared HTTPS session for API calls to speed up operations
+- Add `--version` flag to Assigner
 
 ## 1.1.1
 
 - Fixed `get` failing to clone new repos with error `Remote branch ['master'] not found in upstream origin`
-- Add `--version` flag to Assigner
 
 ## 1.1.0
 

--- a/assigner/baserepo.py
+++ b/assigner/baserepo.py
@@ -11,6 +11,10 @@ from requests.exceptions import HTTPError
 from urllib.parse import urlsplit, urlunsplit, urljoin, quote
 
 
+# Transparently use a common TLS session for each request
+requests = requests.Session()
+
+
 class RepoError(Exception):
     pass
 


### PR DESCRIPTION
This also seems to reduce the chance of TLS negotiation errors that we've been seeing.