### PR TITLE
Err/user in group

### DIFF
--- a/assigner/__init__.py
+++ b/assigner/__init__.py
@@ -82,8 +82,10 @@ def manage_repos(conf, backend, args, action):
 
         repo = backend.student_repo(backend_conf, namespace, full_name)
         if not dry_run:
-            action(repo, student)
-        count += 1
+            if action(repo, student):
+                count += 1
+        else:
+            count += 1
 
     print("Changed {} repositories.".format(count))
 

--- a/assigner/backends/exceptions.py
+++ b/assigner/backends/exceptions.py
@@ -5,4 +5,3 @@ class UserInAssignerGroup(AssignerException):
 
 class UserNotAssigned(AssignerException):
     """ A student is not a member of their homework repository. """
-    pass

--- a/assigner/backends/exceptions.py
+++ b/assigner/backends/exceptions.py
@@ -1,0 +1,8 @@
+from assigner.exceptions import AssignerException
+
+class UserInAssignerGroup(AssignerException):
+    """ A student is a member of the group/namespace assigner is creating assignments in. This may make some operatons, such as assigning homework, no-ops as they already have access. """
+
+class UserNotAssigned(AssignerException):
+    """ A student is not a member of their homework repository. """
+    pass

--- a/assigner/backends/gitlab.py
+++ b/assigner/backends/gitlab.py
@@ -20,6 +20,7 @@ from assigner.backends.base import (
 
 from assigner.backends.gitlab_exceptions import (
     raiseUserInAssignerGroup,
+    raiseUserNotAssigned,
 )
 
 # Transparently use a common TLS session for each request
@@ -310,6 +311,7 @@ class GitlabRepo(RepoBase):
             )
         except HTTPError as e:
             raiseUserInAssignerGroup(e)
+            raiseUserNotAssigned(e)
             raise e
 
     def delete_member(self, user_id):

--- a/assigner/backends/gitlab.py
+++ b/assigner/backends/gitlab.py
@@ -18,6 +18,9 @@ from assigner.backends.base import (
     TemplateRepoBase
 )
 
+from assigner.backends.gitlab_exceptions import (
+    raiseUserInAssignerGroup,
+)
 
 # Transparently use a common TLS session for each request
 requests = requests.Session()
@@ -289,7 +292,11 @@ class GitlabRepo(RepoBase):
             "user_id": user_id,
             "access_level": level.value
         }
-        return self._gl_post("/projects/{}/members".format(self.id), payload)
+        try:
+            return self._gl_post("/projects/{}/members".format(self.id), payload)
+        except HTTPError as e:
+            raiseUserInAssignerGroup(e)
+            raise e
 
     def edit_member(self, user_id, level):
         payload = {
@@ -297,9 +304,13 @@ class GitlabRepo(RepoBase):
             "user_id": user_id,
             "access_level": level.value
         }
-        return self._gl_put(
-            "/projects/{}/members/{}".format(self.id, user_id), payload
-        )
+        try:
+            return self._gl_put(
+                "/projects/{}/members/{}".format(self.id, user_id), payload
+            )
+        except HTTPError as e:
+            raiseUserInAssignerGroup(e)
+            raise e
 
     def delete_member(self, user_id):
         return self._gl_delete(

--- a/assigner/backends/gitlab_exceptions.py
+++ b/assigner/backends/gitlab_exceptions.py
@@ -28,3 +28,15 @@ def raiseUserInAssignerGroup(err: HTTPError):
         return
 
     raise UserInAssignerGroup(err)
+
+def raiseUserNotAssigned(err: HTTPError):
+    """
+    Request url:
+        PUT /api/v4/projects/{}/members/{}
+
+    Expected response: HTTP 404
+    """
+    if err.response.status_code != 404:
+        return
+
+    raise UserNotAssigned(err)

--- a/assigner/backends/gitlab_exceptions.py
+++ b/assigner/backends/gitlab_exceptions.py
@@ -1,0 +1,30 @@
+from requests.exceptions import HTTPError
+
+from assigner.backends.exceptions import (
+    UserInAssignerGroup,
+    UserNotAssigned,
+)
+
+def raiseUserInAssignerGroup(err: HTTPError):
+    """
+    Request urls:
+        PUT  /api/v4/projects/{}/members/{}
+        POST /api/v4/projects/{}/members
+
+    Expected response: HTTP 400 with json
+    {'message': {'access_level': ['should be higher than Maintainer inherited membership from group assigner-testing']}}
+    """
+    if err.response.status_code != 400:
+        return
+
+    json = err.response.json()
+
+    try:
+        access_level_message = json["message"]["access_level"][0]
+    except (KeyError, IndexError):
+        return
+
+    if "inherited membership from group" not in access_level_message:
+        return
+
+    raise UserInAssignerGroup(err)

--- a/assigner/commands/lock.py
+++ b/assigner/commands/lock.py
@@ -1,6 +1,7 @@
 import logging
 
 from assigner import manage_repos
+from assigner.backends.exceptions import UserInAssignerGroup
 
 help = "Lock students out of repos"
 
@@ -12,11 +13,13 @@ def lock(args):
     they cannot push changes, etc.
     """
     #pylint: disable=no-value-for-parameter
-    return manage_repos(
-        args,
-        lambda repo, student: repo.lock(student["id"])
-    )
+    return manage_repos(args, _lock)
 
+def _lock(repo, student):
+    try:
+        repo.lock(student["id"])
+    except UserInAssignerGroup:
+        logging.info("%s cannot be locked out because they are a member of the group, skipping...", student["username"])
 
 def setup_parser(parser):
     parser.add_argument("name",

--- a/assigner/commands/lock.py
+++ b/assigner/commands/lock.py
@@ -1,7 +1,10 @@
 import logging
 
 from assigner import manage_repos
-from assigner.backends.exceptions import UserInAssignerGroup
+from assigner.backends.exceptions import (
+        UserInAssignerGroup,
+        UserNotAssigned,
+    )
 
 help = "Lock students out of repos"
 
@@ -18,8 +21,13 @@ def lock(args):
 def _lock(repo, student):
     try:
         repo.lock(student["id"])
+        return True
     except UserInAssignerGroup:
         logging.info("%s cannot be locked out because they are a member of the group, skipping...", student["username"])
+        return False
+    except UserNotAssigned:
+        logging.info("%s has not been assigned for %s", repo.name, student["username"])
+        return False
 
 def setup_parser(parser):
     parser.add_argument("name",

--- a/assigner/commands/open.py
+++ b/assigner/commands/open.py
@@ -4,6 +4,7 @@ from requests.exceptions import HTTPError
 
 from assigner.backends.base import RepoError
 from assigner.backends.decorators import requires_config_and_backend
+from assigner.backends.exceptions import UserInAssignerGroup
 from assigner.roster_util import get_filtered_roster
 from assigner import progress
 
@@ -49,6 +50,8 @@ def open_all_assignments(conf, backend, args):
 
             open_assignment(repo, student, backend.access.developer)
             count += 1
+        except UserInAssignerGroup:
+            logging.info("%s already has access via group membership, skipping...", username)
         except RepoError:
             logging.warning("Could not add %s to %s.", username, full_name)
 

--- a/assigner/commands/unlock.py
+++ b/assigner/commands/unlock.py
@@ -1,7 +1,10 @@
 import logging
 
 from assigner import manage_repos
-from assigner.backends.exceptions import UserInAssignerGroup
+from assigner.backends.exceptions import (
+        UserInAssignerGroup,
+        UserNotAssigned,
+    )
 
 help = "Unlock student's repo"
 
@@ -17,8 +20,13 @@ def unlock(args):
 def _unlock(repo, student):
     try:
         repo.unlock(student["id"])
+        return True
     except UserInAssignerGroup:
         logging.info("%s cannot be locked out because they are a member of the group, skipping...", student["username"])
+        return False
+    except UserNotAssigned:
+        logging.info("%s has not been assigned for %s", repo.name, student["username"])
+        return False
 
 def setup_parser(parser):
     parser.add_argument("name",

--- a/assigner/commands/unlock.py
+++ b/assigner/commands/unlock.py
@@ -1,6 +1,7 @@
 import logging
 
 from assigner import manage_repos
+from assigner.backends.exceptions import UserInAssignerGroup
 
 help = "Unlock student's repo"
 
@@ -11,11 +12,13 @@ def unlock(args):
     """Sets each student to Developer status on their homework repository.
     """
     #pylint: disable=no-value-for-parameter
-    return manage_repos(
-        args,
-        lambda repo, student: repo.unlock(student["id"])
-    )
+    return manage_repos(args, _unlock)
 
+def _unlock(repo, student):
+    try:
+        repo.unlock(student["id"])
+    except UserInAssignerGroup:
+        logging.info("%s cannot be locked out because they are a member of the group, skipping...", student["username"])
 
 def setup_parser(parser):
     parser.add_argument("name",

--- a/assigner/exceptions.py
+++ b/assigner/exceptions.py
@@ -1,0 +1,3 @@
+
+class AssignerException(Exception):
+    """ The top of the 'expected assigner exceptions' hierarchy. If one of these isn't caught, that's a bug. """


### PR DESCRIPTION
Begin the process of abstracting errors from Gitlab/git backends (see #8). The intent is that eventually every exception Assigner throws internally is a subclass of `AssignerException` which will allow us to (later on down the road) write something like this in the main function:

```
try:
    # do the assigner command thing
except AssignerException as e:
    # print nice errors and exit
except Exception as e:
    logger.error("Uncaught exception %s", e)
    logger.error("This is a bug. Please file an issue here: https://github.com/redkyn/assigner/issues/new")
```

Backends are responsible for wrapping their own HTTPErrors or the like. `raiseUserInAssignerGroup` offers an example of how to do this easily.