### PR TITLE
Git clone exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Devel
 
+- Retry clones that fail with 'Connection reset by peer' using exponential backoff
 - Offer to create GitLab group in `assigner init`
 - Version configuration; automatically upgrade old configs to latest version
 - Make GitLab backend configuration generic

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -154,6 +154,8 @@ You can then inspect and grade the assignments however you like.
 If you want to collect late submissions, you can re-run `assigner get hw1`.
 It will fetch changes for each existing repository and clone any nonexisting repositores.
 
+If you encounter 'Connection reset by peer' errors when cloning, run, say, `assigner get hw1 --attempts=10` to have Assigner try cloning 10 times before giving up.
+
 (Assigner doesn't have plans for any grading features;
 however, if you are interested in automated grading, check out its sister project, [grader](https://github.com/redkyn/grader).)
 

--- a/assigner/backends/base.py
+++ b/assigner/backends/base.py
@@ -63,7 +63,7 @@ class RepoBase:
     def pull(self, branch: str) -> None:
         raise NotImplementedError
 
-    def clone_to(self, dir_name: str, branch: Optional[str]) -> None:
+    def clone_to(self, dir_name: str, branch: Optional[str], attempts: Optional[int]) -> None:
         raise NotImplementedError
 
     def add_local_copy(self, dir_name: str) -> None:

--- a/assigner/backends/exceptions.py
+++ b/assigner/backends/exceptions.py
@@ -5,3 +5,6 @@ class UserInAssignerGroup(AssignerException):
 
 class UserNotAssigned(AssignerException):
     """ A student is not a member of their homework repository. """
+
+class RetryableGitError(AssignerException):
+    """ Git has encountered an error that may be spurious. """

--- a/assigner/backends/git_exceptions.py
+++ b/assigner/backends/git_exceptions.py
@@ -1,0 +1,23 @@
+from git.exc import GitCommandError
+
+from assigner.backends.exceptions import (
+    RetryableGitError,
+)
+
+def raiseRetryableGitError(err: GitCommandError):
+    """
+    Intended to catch git errors that might be able to be recovered from,
+    such as 'Connection reset by peer' when cloning.
+
+    We may need to make the criteria more specific but that will be left for a future bug report!
+    """
+
+    try:
+        status = int(err.status)
+    except (ValueError, TypeError):
+        return
+
+    if status != 128:
+        return
+
+    raise RetryableGitError(err)

--- a/assigner/backends/mock.py
+++ b/assigner/backends/mock.py
@@ -141,7 +141,7 @@ class MockRepo(RepoBase):
         if self.repo is None:
             raise RepoError("No repo to pull to")
 
-    def clone_to(self, dir_name, branch=None):
+    def clone_to(self, dir_name, branch=None, attempts=1):
         logging.debug("Cloning %s...", self.ssh_url)
         if branch:
             self._repo = MockGitRepo.clone_from(self.ssh_url, dir_name,


### PR DESCRIPTION
This may help fix some longstanding problems with GitLab giving spurious `Connection reset by peer` errors when attempting to clone new repositories.

We may want to make the criteria for raising `FatalGitError` a bit more stringent -- perhaps checking for `connection reset by peer` or the like?

We may also want to hold off on including this in 2.0 in order to get some real-world testing in first.

Fixes #127.