### PR TITLE
Bump enlighten to 1.5.0 to fix latin1 encoding problem and release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Fix issue where ASCII-only terminals cannot display progress bars
+
 ## 2.0.0
 
 - Added 'commit' command to commit changes to student repos

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ python-utils==2.2.0
 nose==1.3.7
 nose-parameterized==0.6.0
 setuptools_scm==1.15.7
-enlighten==1.1.0
+enlighten==1.5.0

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'jsonschema>=2.5',
         'requests>=2.20.0',
         'PTable>=0.9',
-        'enlighten>=1',
+        'enlighten>=1.5.0',
         'redkyn-common>=1.0.1',
     ],
 


### PR DESCRIPTION
See https://github.com/redkyn/assigner/issues/144 and https://github.com/Rockhopper-Technologies/enlighten/issues/13 for details.

Fixes #144 