### PR TITLE
Minor "assigner score" improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Change `score` command defaults to be more generic, fix a bug when a student's repo
+  does not exist
+- Add `-S` option to `commit` command to allow for GPG-signed commits
+
 ## 3.0.0
 
 - Add auto-uploading functionality with `score` command to grab autograder results

--- a/assigner/commands/commit.py
+++ b/assigner/commands/commit.py
@@ -89,9 +89,9 @@ def _push(conf, backend, args):
                     # launching via repo.git.commit will launch an inaccessible
                     # interactive prompt in the background
                     index.write()
-                    subprocess.call(["git", "commit", "-S", "-m", '"{}"'.format(message)],
-                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                                    cwd=repo_dir)
+                    subprocess.check_call(["git", "commit", "-S", "-m", '"{}"'.format(message)],
+                                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                          cwd=repo_dir)
                 else:
                     index.commit(message)
             else:

--- a/assigner/commands/commit.py
+++ b/assigner/commands/commit.py
@@ -88,8 +88,10 @@ def _push(conf, backend, args):
                     # The GitPython interface does not support signed commits, and
                     # launching via repo.git.commit will launch an inaccessible
                     # interactive prompt in the background
+                    index.write()
                     subprocess.call(["git", "commit", "-S", "-m", '"{}"'.format(message)],
-                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                    cwd=repo_dir)
                 else:
                     index.commit(message)
             else:

--- a/assigner/commands/commit.py
+++ b/assigner/commands/commit.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import subprocess
 
 from requests.exceptions import HTTPError
 from git.exc import NoSuchPathError
@@ -31,6 +32,7 @@ def _push(conf, backend, args):
     remove = args.remove
     update = args.update
     allow_empty = args.allow_empty
+    gpg_sign = args.gpg_sign
 
     # Default behavior: commit changes to all tracked files
     if (add == []) and (remove == []):
@@ -82,7 +84,14 @@ def _push(conf, backend, args):
 
             if has_changes or allow_empty:
                 logging.debug("%s: committing changes with message %s", full_name, message)
-                index.commit(message)
+                if gpg_sign:
+                    # The GitPython interface does not support signed commits, and
+                    # launching via repo.git.commit will launch an inaccessible
+                    # interactive prompt in the background
+                    subprocess.call(["git", "commit", "-S", "-m", '"{}"'.format(message)],
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                else:
+                    index.commit(message)
             else:
                 logging.warning("%s: No changes in repo; skipping commit.", full_name)
 
@@ -113,6 +122,8 @@ def setup_parser(parser):
                         help="Include all changed files (i.e., git add -u or git commit -a)")
     parser.add_argument("-e", "--allow-empty", action="store_true", dest="allow_empty",
                         help="Commit even if there are no changes to commit")
+    parser.add_argument("-S", "--gpg-sign", action="store_true", dest="gpg_sign",
+                        help="GPG-sign the commits using the committer identity")
     parser.add_argument("--section", nargs="?",
                         help="Section to commit to")
     parser.add_argument("--student", metavar="id",

--- a/assigner/commands/score.py
+++ b/assigner/commands/score.py
@@ -299,6 +299,7 @@ def handle_scoring(
     except RepoError as e:
         logger.debug(e)
         logger.warning("Unable to find repo for %s with URL %s", username, full_name)
+        score = None
     return score
 
 
@@ -409,7 +410,7 @@ def setup_parser(parser: argparse.ArgumentParser):
             "--files",
             nargs="+",
             dest="files",
-            default=["grade.sh", ".gitlab-ci.yml"],
+            default=[".gitlab-ci.yml"],
             help="Files to check for modification",
         )
 


### PR DESCRIPTION
This PR adds support for signed commits - this required a call via `subprocess` instead of through the GitPython wrapper.
I'm not sure if we'd want to allow the user to specify a key ID other than the one that corresponds to the committer email - `assigner score` requires that these match, but perhaps there's some other use case that I'm not considering.

It also makes some minor changes to `assigner score` - I opted to set the default list of files to check to be just `.gitlab-ci.yml` instead of hardcoding a specific use case.

A small bug was also fixed in `handle_scoring` - if the student repo does not exist, `score` should be set to `None` to match the annotated `Optional[Float]` return type, instead of attempting to return a variable that was never defined.

Thanks to @BehindTheBrain for catching these and suggesting fixes!  Feel free to test these out - I was able to test the signed commits locally but my test environment for `assigner score` isn't as sophisticated as the real thing.

Resolves #152
Resolves #153
Resolves #154 