### PR TITLE
Ignore git index extension data when writing index

### DIFF
--- a/assigner/commands/commit.py
+++ b/assigner/commands/commit.py
@@ -88,7 +88,7 @@ def _push(conf, backend, args):
                     # The GitPython interface does not support signed commits, and
                     # launching via repo.git.commit will launch an inaccessible
                     # interactive prompt in the background
-                    index.write()
+                    index.write(ignore_extension_data=True)
                     subprocess.check_call(["git", "commit", "-S", "-m", '"{}"'.format(message)],
                                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                                           cwd=repo_dir)


### PR DESCRIPTION
Otherwise, `git commit` will not commit changes, even though they are visible to `git status`.

See https://github.com/gitpython-developers/GitPython/issues/1185

Fixes #160.